### PR TITLE
Prevent non-moderators from adding other members to modmail threads

### DIFF
--- a/src/main/java/com/thefatrat/eddiejunior/components/impl/ModMailComponent.java
+++ b/src/main/java/com/thefatrat/eddiejunior/components/impl/ModMailComponent.java
@@ -415,7 +415,7 @@ public class ModMailComponent extends DirectMessageComponent {
         String topic = String.format("t%d-%s", threadId, subject);
         topic = topic.substring(0, Math.min(topic.length(), 100));
 
-        ThreadChannel thread = destination.createThreadChannel(topic, privateThreads).complete();
+        ThreadChannel thread = destination.createThreadChannel(topic, privateThreads).setInvitable(false).complete();
         String urls = "";
         if (!attachments.isEmpty()) {
             List<String> list = new ArrayList<>();


### PR DESCRIPTION
This [change](https://docs.jda.wiki/net/dv8tion/jda/api/requests/restaction/ThreadChannelAction.html#setInvitable(boolean)) prevents normal members from mentioning other members to add them to the modmail thread. Only moderators can add other members to the thread.

If this change is not desired, then feel free to close the PR.